### PR TITLE
[fix] add ThinkPad X13 Gen 1 into inversion models for rtsx

### DIFF
--- a/rtsx.c
+++ b/rtsx.c
@@ -197,6 +197,7 @@ static const struct rtsx_inversion_model {
 	char	*product;
 } rtsx_inversion_models[] = {
 	{ "LENOVO",		"ThinkPad T470p",	"20J7S0PM00"},
+	{ "LENOVO",             "ThinkPad X13 Gen 1",   "20UF000QRT"},
 	{ NULL,			NULL,			NULL}
 };
 


### PR DESCRIPTION
ThinkPad X13 Gen 1 has same issue with inversion as 470p. Let's add it into inversion models. 

BTW, thank you for your effort with rtsx! 